### PR TITLE
Filtering by embargo period

### DIFF
--- a/_includes/model.html
+++ b/_includes/model.html
@@ -1,9 +1,15 @@
 {% case include.model %}
   {% when "diamond" %}
-    <span role="img" class="icon" data-tooltip="Diamond open access" data-placement="left">💎</span>
+    {% if include.embargo > 0 %}
+      <span role="img" class="icon" data-tooltip="Diamond open access after embargo" data-placement="right">
+        💎<sub>⌛</sub>
+      </span>
+    {% else %}
+      <span role="img" class="icon" data-tooltip="Diamond open access" data-placement="right">💎</span>
+    {% endif %}
   {% when "gold" %}
-    <span role="img" class="icon" data-tooltip="Gold open access" data-placement="left">🪙</span>
+    <span role="img" class="icon" data-tooltip="Gold open access" data-placement="right">🪙</span>
   {% else %}
-    <span role="img" class="icon" data-tooltip="Unknown open access model" data-placement="left">❓</span>
+    <span role="img" class="icon" data-tooltip="Unknown open access model" data-placement="right">❓</span>
 {% endcase %}
 

--- a/_journals/paléorient.md
+++ b/_journals/paléorient.md
@@ -1,6 +1,7 @@
 ---
 title: Paléorient
 model: diamond
+embargo: 24
 peer_reviewed: true
 website: https://journals.openedition.org/paleorient/
 issn: 1957-701X

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -44,7 +44,7 @@ layout: base
 
                 <tr>
                   <td class="model center">
-                    {% include model.html model=journal.model %}
+                    {% include model.html model=journal.model embargo=journal.embargo %}
                   </td>
                   <td class="title" data-title="{{ journal.title }}">
                     <cite>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,7 +25,7 @@ layout: base
 
           <label>
             <input id="embargo-filter-control" name="embargo" type="checkbox" role="switch" class="filter" disabled />
-            Include embargoed
+            Show embargoed
           </label>
 
         </fieldset>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,10 +16,19 @@ layout: base
 
       <article>
 
-        <p><noscript><small>Searching and sorting requires a Javascript-enabled browser!</small></noscript></p>
+        <p><noscript><small>Searching, filtering and sorting requires a Javascript-enabled browser.</small></noscript></p>
         <form role="search">
           <input type="search" class="search" placeholder="Filter..." disabled />
         </form>
+
+        <fieldset class="grid">
+
+          <label>
+            <input id="embargo-filter-control" name="embargo" type="checkbox" role="switch" class="filter" disabled />
+            Include embargoed
+          </label>
+
+        </fieldset>
 
         <div class=table-container>
           <table>
@@ -27,6 +36,7 @@ layout: base
               <th scope="col">
                 <button class="outline sort" data-sort="model" title="Sort by open access model" disabled></button>
               </th>
+              <th scope="col" class="journal-col" hidden>Embargo</th>
               <th scope="col" class="journal-col">
                 <strong>Journal</strong>
                 <button class="outline sort" data-sort="title" title="Sort by title" disabled></button>
@@ -46,6 +56,7 @@ layout: base
                   <td class="model center">
                     {% include model.html model=journal.model embargo=journal.embargo %}
                   </td>
+                  <td class="embargo" hidden>{{ journal.embargo }}</td>
                   <td class="title" data-title="{{ journal.title }}">
                     <cite>
                       <a href="{{ journal.website }}" title="{{ journal.title }} home page">

--- a/css/styles.css
+++ b/css/styles.css
@@ -48,6 +48,7 @@ button.sort:focus {
   content: "\2193";
 }
 
+/* Reponsive(ish) table */
 @media screen and (max-width: 720px) {
   .table-container {
     overflow-x:auto;
@@ -59,4 +60,11 @@ button.sort:focus {
     left: 0;
     z-index: 2;
   }
+}
+
+/* OA model icons */
+.model .icon sub {
+  position: relative;
+  left: -16px;
+  margin-right: -16px;
 }

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -2,12 +2,35 @@
 var listOptions = {
   valueNames: [ 
     'model', 
+    'embargo',
     { attr: 'data-title', name: 'title' }, 
     'publisher'
   ]
 };
 
 var journalsList = new List('journals-list', listOptions);
+
+/* Filter out embargoed journals (on by default */
+function embargoFilter(item) {
+  if (item.values().embargo < 1) {
+     return true;
+  } else {
+     return false;
+  }
+}
+
+window.addEventListener('load', function() {
+  journalsList.filter(embargoFilter);
+})
+
+embargoFilterControl = document.getElementById("embargo-filter-control");
+embargoFilterControl.addEventListener('change', function() {
+  if (this.checked) {
+    journalsList.filter(); // N.B. only works as long as there's one filter
+  } else {
+    journalsList.filter(embargoFilter);
+  }
+});
 
 /* Turn on disabled controls */
 searchControls = document.getElementById("journals-list").getElementsByClassName("search");
@@ -17,5 +40,10 @@ Array.from(searchControls).forEach((element) => {
 
 sortControls = document.getElementById("journals-list").getElementsByClassName("sort");
 Array.from(sortControls).forEach((element) => {
+  element.disabled = false;
+});
+
+filterControls = document.getElementById("journals-list").getElementsByClassName("filter");
+Array.from(filterControls).forEach((element) => {
   element.disabled = false;
 });

--- a/oa-models.md
+++ b/oa-models.md
@@ -11,6 +11,9 @@ Various models have emerged for achieving this aim, which are sustained in diffe
 These venues are usually community-run, and are typically funded through academic institutions, philanthropists or government grants.
 Diamond OA is sometimes also referred to as "Platinum" OA.
 
+⌛ **Embargoed**: some journals only make articles available in open access after an 'embargo' period, during which they are only accessible to subscribers.
+We filter these from our list by default, but they can be shown using the "Show embargoed" toggle.
+
 🌿 **Green OA** refers to self-archiving of research outputs in publicly-accessible institutional or subject repositories.
 Articles posted to a Green OA repository may, but must not necessarily, derive from traditional publishing protocols.
 This model therefore affords great flexibility.


### PR DESCRIPTION
Adds an icon for journals with an embargo period (#3) and a control for filtering those from the lists. By default they are *not* included, based on what @rossmounce said about these technically not being diamond.

Also fixed the embargo field of one journal (*Paléorient*).